### PR TITLE
Add transpilation to C#

### DIFF
--- a/xmlscript/Extensions.cs
+++ b/xmlscript/Extensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace xmlscript
+{
+    public static class Extensions
+    {
+        public static string Join<T>(this IEnumerable<T> i, string sep)
+        {
+            string output = "";
+
+            foreach(T item in i)
+            {
+                output += item.ToString() + sep;
+            }
+
+            if(output.Length >= sep.Length) output = output.Substring(0, output.Length-sep.Length);
+            return output;
+        }
+    }
+
+    public static class Utils
+    {
+        public static string SemicolonOptional(Dictionary<string, object> args)
+        {
+            return (args != null && args["NoSemicolon"] != null && ((bool)args["NoSemicolon"])) ? "" : ";";
+        }
+    }
+}

--- a/xmlscript/FinalNodes/CallNode.cs
+++ b/xmlscript/FinalNodes/CallNode.cs
@@ -51,6 +51,18 @@ namespace xmlscript.FinalNodes
             return null;
         }
 
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            List<string> methodArgs = new List<string>();
+
+            foreach(Node argNode in argumentNodes)
+            {
+                methodArgs.Add(argNode.Transpile(scope));
+            }
+
+            return $"{attrTypeTarget}.{attrMethodTarget}({methodArgs.Join(", ")});";
+        }
+
         public static Type ResolveType(string name)
         {
             foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())

--- a/xmlscript/FinalNodes/ConditionalNode.cs
+++ b/xmlscript/FinalNodes/ConditionalNode.cs
@@ -104,5 +104,10 @@ namespace xmlscript.FinalNodes
 
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return $"{LeftSide.Transpile(scope)} {Op} {RightSide.Transpile(scope)}";
+        }
     }
 }

--- a/xmlscript/FinalNodes/ForNode.cs
+++ b/xmlscript/FinalNodes/ForNode.cs
@@ -58,5 +58,13 @@ namespace xmlscript.FinalNodes
 
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            Scope newScope = Scope.FromParent(scope);
+            return @$"for({InitNode.Transpile(newScope)} {ConditionalNode.Transpile(newScope)}; {StepNode.Transpile(newScope)}) {{
+    {FunctionNode.Transpile(newScope)}
+            }}";
+        }
     }
 }

--- a/xmlscript/FinalNodes/IfNode.cs
+++ b/xmlscript/FinalNodes/IfNode.cs
@@ -49,5 +49,14 @@ namespace xmlscript.FinalNodes
 
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return $@"if({ConditionalNode.Transpile(scope)}) {{
+    {FunctionNode.Transpile(scope)}
+}}{(ElseFunctionNode != null ? $@"else {{
+    {ElseFunctionNode.Transpile(scope)}
+}}" : "")}";
+        }
     }
 }

--- a/xmlscript/FinalNodes/Node.cs
+++ b/xmlscript/FinalNodes/Node.cs
@@ -10,6 +10,10 @@ namespace xmlscript.FinalNodes
     public abstract class Node
     {
         public abstract object Visit(Scope scope);
+        public virtual string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            throw new Exception(this.GetType().Name + " does not support transpilation to C#");
+        }
         public abstract Node FromXmlTag(XmlNode node);
     }
 }

--- a/xmlscript/FinalNodes/NodeCollection.cs
+++ b/xmlscript/FinalNodes/NodeCollection.cs
@@ -31,5 +31,12 @@ namespace xmlscript.FinalNodes
             foreach (Node node in Nodes) node.Visit((ownScope ? Scope.FromParent(scope) : scope));
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            string output = "";
+            foreach (Node node in Nodes) output += node.Transpile(scope) + "\n";
+            return output;
+        }
     }
 }

--- a/xmlscript/FinalNodes/NumberNode.cs
+++ b/xmlscript/FinalNodes/NumberNode.cs
@@ -22,5 +22,10 @@ namespace xmlscript.FinalNodes
         {
             return val;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return val.ToString();
+        }
     }
 }

--- a/xmlscript/FinalNodes/PassNode.cs
+++ b/xmlscript/FinalNodes/PassNode.cs
@@ -18,5 +18,10 @@ namespace xmlscript.FinalNodes
         {
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return "";
+        }
     }
 }

--- a/xmlscript/FinalNodes/StringNode.cs
+++ b/xmlscript/FinalNodes/StringNode.cs
@@ -21,5 +21,10 @@ namespace xmlscript.FinalNodes
         {
             return val;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return $"\"{val}\"";
+        }
     }
 }

--- a/xmlscript/FinalNodes/VarAssignNode.cs
+++ b/xmlscript/FinalNodes/VarAssignNode.cs
@@ -27,5 +27,10 @@ namespace xmlscript.FinalNodes
             scope.Set(attrName, valueNode.Visit(scope));
             return null;
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return $"var {attrName} = {valueNode.Transpile(scope)}{Utils.SemicolonOptional(args)}";
+        }
     }
 }

--- a/xmlscript/FinalNodes/VarGetNode.cs
+++ b/xmlscript/FinalNodes/VarGetNode.cs
@@ -22,5 +22,10 @@ namespace xmlscript.FinalNodes
         {
             return scope.Get(attrName);
         }
+
+        public override string Transpile(Scope scope, Dictionary<string, object> args = null)
+        {
+            return attrName;
+        }
     }
 }

--- a/xmlscript/Program.cs
+++ b/xmlscript/Program.cs
@@ -14,6 +14,13 @@ namespace xmlscript
                 {
                     Console.WriteLine("Path to run: ");
                     string path = Console.ReadLine();
+                    bool transpile = false;
+
+                    if (path.EndsWith("-t"))
+                    {
+                        transpile = true;
+                        path = path.Substring(0, path.Length - 2);
+                    }
 
                     XmlDocument doc = new XmlDocument();
                     doc.Load(path);
@@ -26,10 +33,22 @@ namespace xmlscript
                         Node n = ParseNode(doc.GetElementsByTagName("xmlscript")[0]);
                         sw.Stop();
                         Debug.WriteLine("Parsing took " + sw.ElapsedMilliseconds + "ms");
-                        sw.Restart();
-                        n.Visit(new Scope());
-                        sw.Stop();
-                        Debug.WriteLine("Interpreting took " + sw.ElapsedMilliseconds + "ms");
+
+                        if (!transpile)
+                        {
+                            sw.Restart();
+                            n.Visit(new Scope());
+                            sw.Stop();
+                            Debug.WriteLine("Interpreting took " + sw.ElapsedMilliseconds + "ms");
+                        }else
+                        {
+                            sw.Restart();
+                            string output = n.Transpile(new Scope());
+                            sw.Stop();
+                            Debug.WriteLine("Transpilation took " + sw.ElapsedMilliseconds + "ms");
+                            Console.WriteLine(output);
+                            Console.ReadKey();
+                        }
                     }else
                     {
                         Console.WriteLine("No root element found! Needs to be named xmlscript!");

--- a/xmlscript/xmlscript.csproj
+++ b/xmlscript/xmlscript.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Adds the possibility to transpile your XMLScript to C#. This might have some imperfections and bugs and does not check if the XMLScript would be transpilable without errors, but that not needed either.
If a user tries to put a `if` node in the `step` node of a `for` node, it will probably interpret just fine but it definitely wont work in C#.

Transpilation was added to all existing nodes, but can be choosen to not be implemented by specific node types.